### PR TITLE
fixes echo invocation on bash and zsh on OS X 10.8

### DIFF
--- a/requirements/get_requirements.sh
+++ b/requirements/get_requirements.sh
@@ -2,7 +2,7 @@
 
 PROGRAM=`echo $0 | sed 's%.*/%%'`
 
-ECHO="/bin/echo -e"
+ECHO="/bin/echo"
 if type wget >/dev/null 2>/dev/null; then
   FETCH="wget --quiet"
 elif type curl >/dev/null 2>/dev/null; then


### PR DESCRIPTION
BSD echo does not have option -e
