### PR TITLE
Space in path

### DIFF
--- a/bin/swth.sh
+++ b/bin/swth.sh
@@ -66,7 +66,7 @@ if test "x$_T" = "x"; then
   $ECHO "$PROGRAM: cannot find swathesis"
   exit 200
 fi
-TEMPLATEROOT="`dirname $_T`/contrib"
+TEMPLATEROOT="`dirname \"$_T\"`/contrib"
 
 if test -z "$OSTYPE" ; then
   OSTYPE=`uname -s | tr A-Z a-z`


### PR DESCRIPTION
Fixes a problem consisting in the SWTH script not recognizing paths with spaces. (At least an issue with MinGW/Cygwin).
