### PR TITLE
Removes hyphens in english name of HPI

### DIFF
--- a/swa-document-llncs.sty
+++ b/swa-document-llncs.sty
@@ -69,12 +69,12 @@
 
 \addto\captionsenglish{%
   \providecommand*\swa@faculty{%
-    Hasso-Plattner-Institute%
+    Hasso Plattner Institute%
     \\ at the University of Potsdam, Germany%
   }
   \providecommand*\swa@university{%
         Software Architecture Group\\
-        Hasso-Plattner-Institute\\%
+        Hasso Plattner Institute\\%
         University of Potsdam, Germany%
   }
 }

--- a/title-hpi-swa.def
+++ b/title-hpi-swa.def
@@ -117,12 +117,12 @@
 
 \NowButAfterBeginDocument{%
   % \providecaptionname{english}{\@faculty}{%
-  %     Hasso-Plattner-Institute%
+  %     Hasso Plattner Institute%
   %     \\ at the University of Potsdam, Germany%
   %   }
   \providecaptionname{english}{\@university}{%
           Software Architecture Group\\
-          Hasso-Plattner-Institute\\%
+          Hasso Plattner Institute\\%
           University of Potsdam, Germany%
     }
 


### PR DESCRIPTION
The english name of the HPI is written without hyphens. 

See for example: 
* http://hpi.de/en.html
* https://en.wikipedia.org/wiki/Hasso_Plattner_Institute
