### PR TITLE
Fix typo in requirements: 'marcos' -> 'macros'

### DIFF
--- a/requirements/get_requirements.sh
+++ b/requirements/get_requirements.sh
@@ -124,7 +124,7 @@ _get_ctan() {
 }
 
 _get_tds() {
-  _get_tds_ 'marcos/latex/contrib' "$@"
+  _get_tds_ 'macros/latex/contrib' "$@"
 }
 
 _get_tds_font() {


### PR DESCRIPTION
This took a while to figure out. I cannot say I fully understand the scripts, the fix is more like "this does not look quite right". Reproduction as follows:

```
$ ./install.sh
<snip>
>> current acronym found [>=2010/09/08].
>> current newpxmath found [>=2017/08/18].
>> current ebgaramond found [>=2013/05/22].
ditto: Couldn't read PKZip signature
$ fix-typo
$ rm requirements/*.zip
$ ./install.sh
<snip>
>> current acronym found [>=2010/09/08].
>> current newpxmath found [>=2017/08/18].
>> current ebgaramond found [>=2013/05/22].
>> installed current lstlinebgrd
>> current babel found [>=2012/05/16].
> Deploying swathesis into /Users/f4lco/Library/texmf
Done
```
