### PR TITLE
Replace deprecated \ifundefinedorrelax command

### DIFF
--- a/swa-abstract.sty
+++ b/swa-abstract.sty
@@ -1,11 +1,11 @@
 \RequirePackage{swa-language}
 \RequirePackage{swa-platform}
 
-\ifundefinedorrelax{abstract}{
+\Ifundefinedorrelax{abstract}{
   \newenvironment{abstract}{}{}
 }{}
 
-\ifundefinedorrelax{zusammenfassung}{
+\Ifundefinedorrelax{zusammenfassung}{
   \newenvironment{zusammenfassung}{}{}
 }{}
 

--- a/swa-acronyms.sty
+++ b/swa-acronyms.sty
@@ -39,7 +39,7 @@
  \acrodef{#1}{#3}%
  \acrodefplural{#1}[{#1\acroshortsuffixfont{#2}}]{{#3\acrolongsuffixfont{#4}}}%
  % support for one-time compilation, too.
- \ifundefinedorrelax{fn@#1}{%
+ \Ifundefinedorrelax{fn@#1}{%
    \newacro{#1}{#3}%
    \newacroplural{#1}[{#1\acroshortsuffixfont{#2}}]{{#3\acrolongsuffixfont{#4}}}%
  }{}%
@@ -62,7 +62,7 @@
     \expandafter\ifx\csname acused@#1\endcsname\AC@used%
        \item[\protect\AC@hypertarget{#1}{\acsfont{\AC@acs{#1}}}] \AC@acl{#1}%
           \ifAC@withpage%
-            \ifundefinedorrelax{r@acro:#1}{%
+            \Ifundefinedorrelax{r@acro:#1}{%
               \PackageInfo{acronym}{%
                 Acronym #1 used in text but not spelled out in
                 full in text}%
@@ -87,8 +87,8 @@
   \fi
 }
 
-\ifundefinedorrelax{@listoftoc}{%
-  \ifundefinedorrelax{toc@heading}{%
+\Ifundefinedorrelax{@listoftoc}{%
+  \Ifundefinedorrelax{toc@heading}{%
     % neither tocbasic, komascript not float available
     % so missuse listoffigures here
     \gdef\ac@listhead{

--- a/swa-document-llncs.sty
+++ b/swa-document-llncs.sty
@@ -17,7 +17,7 @@
 \bibliographystyle{splncs04}%% llncs
 \AtEndPreamble{
   % redo document stuff:
-  \ifundefinedorrelax{hypersetup}{}{%
+  \Ifundefinedorrelax{hypersetup}{}{%
     \hypersetup{%
       pdfpagescrop={92 112 523 778}, % LNCS paper size
     }
@@ -30,7 +30,7 @@
   \else{\thispagestyle{empty}\mbox{}\cleardoublepage}%
   \fi%
 }
-\ifundefinedorrelax{cleardoubleemptypage}{%
+\Ifundefinedorrelax{cleardoubleemptypage}{%
   \newcommand{\cleardoubleemptypage}{\swa@doubleempty}%
 }{}
 
@@ -314,7 +314,7 @@
 \AtBeginDocument{
   \@ifpackageloaded{swa-collate}{}{
     % zusammenfassung only in non-collate
-    \ifundefinedorrelax{zusammenfassung}{
+    \Ifundefinedorrelax{zusammenfassung}{
       \newenvironment{zusammenfassung}{}{}
     }{}
 

--- a/swa-document-scrbook.sty
+++ b/swa-document-scrbook.sty
@@ -190,7 +190,7 @@
 
 \AtEndPreamble{
   % redo document stuff:
-  \ifundefinedorrelax{hypersetup}{}{%
+  \Ifundefinedorrelax{hypersetup}{}{%
     \hypersetup{
       pdftitle={\@title{}: \@subtitle},
       pdfauthor={\@author},

--- a/swa-language.sty
+++ b/swa-language.sty
@@ -2,7 +2,7 @@
 \setdatetoday
 
 \RequirePackage{swa-platform}
-\ifundefinedorrelax{if@swa@german}{
+\Ifundefinedorrelax{if@swa@german}{
   \newif\if@swa@german
 }{}
 

--- a/swa-platform.sty
+++ b/swa-platform.sty
@@ -1,7 +1,7 @@
 \RequirePackage{etoolbox}
 \RequirePackage{ifthen,ifpdf,ifluatex,ifxetex}
 
-\ifcsundef{ifundefinedorrelax}%
+\ifcsundef{Ifundefinedorrelax}%
  {\RequirePackage{scrbase}}%
  {}
 

--- a/swa-statement.sty
+++ b/swa-statement.sty
@@ -42,7 +42,7 @@
 }{
   ~\\[7\baselineskip]%
   %
-  \ifundefinedorrelax{@location}{}{%
+  \Ifundefinedorrelax{@location}{}{%
     \ifx\@location\@empty%
     \else
     \@location, den %


### PR DESCRIPTION
As described in [this komascript post](https://komascript.de/node/2279), `\ifundefinedorrelax` was removed, leading to a compile error. Instead, `\Ifundefinedorrelax` works as a replacement.