### PR TITLE
swth: fix unresolved template markers in file names

### DIFF
--- a/swth
+++ b/swth
@@ -91,17 +91,17 @@ if [ -z "$OSTYPE" ]; then
 fi
 
 if __has_cmd pushd ; then
-  __pushd() { 
-    pushd "$@" 2>/dev/null >dev/null 
+  __pushd() {
+    pushd "$@" 2>/dev/null >/dev/null || exit
   }
-  __popd() { 
-    popd "$@" 2>/dev/null >dev/null 
+  __popd() {
+    popd "$@" 2>/dev/null >/dev/null || exit
   }
 else
   # emulate pushd to our usage
   __pushd() {
     export P_OLDPWD="$PWD"
-    cd $1  2>/dev/null >dev/null 
+    cd $1 2>/dev/null >/dev/null || exit
   }
   __popd() {
     if [ -z "$P_OLDPWD" ]; then
@@ -109,7 +109,7 @@ else
       (exit 1)
       return 1
     else
-      cd "$P_OLDPWD"  2>/dev/null >dev/null
+      cd "$P_OLDPWD"  2>/dev/null >/dev/null || exit
       export P_OLDPWD=
     fi
   }

--- a/swth
+++ b/swth
@@ -267,7 +267,7 @@ _create() {
   if [ -d "$SWTHDIR" ]; then
     $ECHO "Found $SWTHDIR"
   else
-    printf "$SWTHDIR does not yet exist, create? [YES/no]"
+    printf "$SWTHDIR does not yet exist, create? [YES/no] "
     read ANS
     case "$ANS" in
       [Nn][Oo]?) ;;


### PR DESCRIPTION
Funny one. `cd ... >dev/null` (sic!) silently failed unless you actually had a `./dev` folder in your pwd; thus, `__untemplate` would operate from within the wrong directory and find no files with template marker.

Besides fixing the typo, I also fixed SH2164 <https://www.shellcheck.net/wiki/SC2164> by adding `|| exit` after every `cd`/`pushd`/`popd`. (By the way, there are ton of other shellcheck warnings in this file :D) Also note that as the shebang enforces POSIX mode, `__has_cmd pushd` will never return true, essentially making the first code path dead (SC3045, shellcheck makes me feel like someone who understands bash ^^), but I'm going to let sleeping dogs lie ...

See other commits for trivia.