### PR TITLE
Changes bash completion installation to install to user directory

### DIFF
--- a/swth
+++ b/swth
@@ -369,10 +369,10 @@ _install_completion() {
   fi
 
   # Start looking for user's bash completion directory
-  if [ ! -z $BASH_COMPLETION_USER_DIR ]; then
+  if [ -n $BASH_COMPLETION_USER_DIR ]; then
     mkdir -p "$BASH_COMPLETION_USER_DIR/completions"
     COMPLETE_USER_INSTALL_DIR="$BASH_COMPLETION_USER_DIR/completions"
-  elif [ ! -z $XDG_DATA_HOME ]; then
+  elif [ -n $XDG_DATA_HOME ]; then
     mkdir -p "$XDG_DATA_HOME/bash-completion/completions"
     COMPLETE_USER_INSTALL_DIR="$XDG_DATA_HOME/bash-completion/completions"
   else
@@ -381,7 +381,7 @@ _install_completion() {
   fi
 
   # Install the completion script
-  if [ ! -z "$COMPLETE_USER_INSTALL_DIR" ]; then
+  if [ -n "$COMPLETE_USER_INSTALL_DIR" ]; then
     if [ ! -w "$COMPLETE_USER_INSTALL_DIR" ]; then
       printf "\n$COMPLETE_USER_INSTALL_DIR is not writable, continue as root (sudo)? [NO|yes] "
       EOLD=$E

--- a/swth
+++ b/swth
@@ -368,10 +368,22 @@ _install_completion() {
     exit 300
   fi
 
-  COMPLETE_INSTALL_DIR=$(pkg-config --variable=compatdir bash-completion)
-  if [ ! -z "$COMPLETE_INSTALL_DIR" ]; then
-    if [ ! -w "$COMPLETE_INSTALL_DIR" ]; then
-      printf "\n$COMPLETE_INSTALL_DIR is not writable, continue as root (sudo)? [NO|yes] "
+  # Start looking for user's bash completion directory
+  if [ ! -z $BASH_COMPLETION_USER_DIR ]; then
+    mkdir -p "$BASH_COMPLETION_USER_DIR/completions"
+    COMPLETE_USER_INSTALL_DIR="$BASH_COMPLETION_USER_DIR/completions"
+  elif [ ! -z $XDG_DATA_HOME ]; then
+    mkdir -p "$XDG_DATA_HOME/bash-completion/completions"
+    COMPLETE_USER_INSTALL_DIR="$XDG_DATA_HOME/bash-completion/completions"
+  else
+    mkdir -p "$HOME/.local/share/bash-completion/completions"
+    COMPLETE_USER_INSTALL_DIR="$HOME/.local/share/bash-completion/completions"
+  fi
+
+  # Install the completion script
+  if [ ! -z "$COMPLETE_USER_INSTALL_DIR" ]; then
+    if [ ! -w "$COMPLETE_USER_INSTALL_DIR" ]; then
+      printf "\n$COMPLETE_USER_INSTALL_DIR is not writable, continue as root (sudo)? [NO|yes] "
       EOLD=$E
       read ANS
       case "$ANS" in
@@ -379,7 +391,7 @@ _install_completion() {
           *) exit 2 ;;
       esac
     fi
-    $ECHO 'complete -W "latex bibtex go gloss show clean" swth' | $E tee -a "$COMPLETE_INSTALL_DIR"/swth >/dev/null
+    $ECHO 'complete -W "latex bibtex go gloss show clean" swth' | $E tee -a "$COMPLETE_USER_INSTALL_DIR"/swth >/dev/null
     E=$EOLD
   else
     $ECHO ">> no automatic installation directory found, skipping configuration of auto completion."


### PR DESCRIPTION
Should address #55 

The search for the user directory is somewhat involved to be backwards-compatible. Newer versions of bash-completion advertise the user-completions directory, older versions do not, but still use it.